### PR TITLE
Fix url.js to accept urls with query parameters

### DIFF
--- a/url.js
+++ b/url.js
@@ -8,7 +8,7 @@ var Url = function(u)
 {
   if(u) {
     this.qurl = url.parse(u);
-    this.params = qs.parse(this.qurl.search);
+    this.params = qs.parse(this.qurl.query);
   }
   return this;
 };


### PR DESCRIPTION
I had to replace `qurl.search` by `qurl.query` in order to not have an additional `?` in the request.
My use case is the following:
 - I request for several object
 - The server give me 20 objects and an url to call to get the next 20 objects
 - I use this url to get the objects 