### PR TITLE
add merge HTTP operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ odata({service: 'https://example.com/Customers'}).top(5).query() // 'https://exa
 * `post(body, options)`
 * `put(body, options)`
 * `patch(body, options)`
+* `merge(body, options)`
 * `delete(options)`
 
 Perform an HTTP operation. For non-batched queries, these will return a promise which resolves to an HTTP response.

--- a/odata.js
+++ b/odata.js
@@ -374,6 +374,29 @@ Odata.prototype.patch = function(body, options)
   return request.patchAsync(options);
 };
 
+Odata.prototype.merge = function(body, options)
+{
+  options = options || {};
+  options.headers = options.headers || {};
+  if(options.content_id) {
+    options.headers['Content-ID'] = options.content_id;
+  }
+  if(this._batch) {
+    this._batch.merge(body, options);
+    return this;
+  }
+  options.url = this.query();
+  options.headers = _.assign({}, this._headers, options.headers);
+  if(_.isPlainObject(body)) {
+    options.body = JSON.stringify(body);
+    options.headers['Content-Type'] = 'application/json';
+  } else {
+    options.body = body;
+  }
+  options.method = 'MERGE';
+  return Promise.promisify(request)(options);
+};
+
 Odata.prototype.delete = function(options)
 {
   options = options || {};

--- a/spec/merge_spec.js
+++ b/spec/merge_spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const odata = require('../index');
+const request = require('../request');
+
+
+const config = {
+  version: '2.0',
+  headers: {Accept: 'application/json'}
+};
+
+describe('Merge (ODATA v2) tests', function () {
+
+  it('should merge a product', function (done) {
+
+    request({
+      uri: 'http://services.odata.org/V2/(S(readwrite))/OData/OData.svc',
+      followRedirect: false
+    }, function (err, response) {
+
+      var q = function () {
+        return odata(Object.assign({service: 'http://services.odata.org' + response.headers.location}, config));
+      };
+      var productId;
+
+      // get every products
+      q().resource('Products')
+        .get()
+        .then(function (res) {
+          expect(res.statusCode).toEqual(200);
+          productId = JSON.parse(res.body).d[0].ID;
+
+          // update the first product
+          return q().resource('Products', productId)
+            .merge({Name: 'Updated Bread'});
+        })
+        .then(function (res) {
+          expect(res.statusCode).toEqual(204);
+
+          // get the updated product
+          return q().resource('Products', productId).get()
+        })
+        .then(function (res) {
+          expect(res.statusCode).toEqual(200);
+          var updatedProduct = JSON.parse(res.body).d;
+          expect(updatedProduct.Name).toEqual('Updated Bread');
+        })
+        .catch(function (err) {
+          fail(err);
+        })
+        .finally(done);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Hi,

I'm using an ODATA v2 service and I need the MERGE operation.
I implemented it and I added 1 test.

The spec is there: http://www.odata.org/documentation/odata-version-2-0/operations/#UpdatingEntries

Regards