### PR TITLE
fix batch requests for MERGE operation

### DIFF
--- a/batch.js
+++ b/batch.js
@@ -110,6 +110,13 @@ Batch.prototype.patch = function(body, options)
   return;
 }
 
+Batch.prototype.merge = function(body, options)
+{
+  this.ops.push(process.call(this, 'MERGE', options, body));
+  this.reset();
+  return;
+}
+
 Batch.prototype.delete = function(options)
 {
   this.ops.push(process.call(this, 'DELETE', options));
@@ -128,8 +135,7 @@ Batch.prototype.body = function()
           msg += `--${last_changeset}--\r\n`;
         }
         msg += `--${this.boundary}\r\n`;
-        msg += `Content-Type: multipart/mixed; boundary=${op.changeset}\r\n`;
-        msg += 'Content-Transfer-Encoding: binary\r\n\r\n';
+        msg += `Content-Type: multipart/mixed; boundary=${op.changeset}\r\n\r\n`;
       }
       msg += `--${op.changeset}\r\n`;
     } else {

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -5,5 +5,6 @@
   ],
   "helpers": [
     "helpers/**/*.js"
-  ]
+  ],
+  "random": false
 }


### PR DESCRIPTION
I forgot to handle merge in Batch.
In addition I had to Batch.body(). I'm not 100% sure it works with OData V3 and V4 but every test pass.
I also fixed jasmine.json not to run test in a random order, it is not supported by the tests.