### PR TITLE
fix dupplicate of content-type header in batch subrequests

### DIFF
--- a/spec/batch_spec.js
+++ b/spec/batch_spec.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Odata = require('../index');
+
+const config = {
+    service: 'https://example.com',
+    resources: 'Customers'
+};
+
+describe('batch tests', function () {
+
+    let odata;
+    beforeEach(function () {
+        odata = Odata(config).batch();
+    });
+
+    it('should contain only one Content-Type header by subrequest', function () {
+
+        odata.post('<?xml version = "1.0" encoding="UTF-8" standalone="yes" ?><test></test>', {
+            headers: { "Content-Type": "application/xml"}
+        });
+
+        odata.post('<html><header></header><body></body></html>', {
+            headers: { "Content-Type": "text/html"}
+        });
+
+        let buff = Buffer.alloc ? Buffer.alloc(64) : new Buffer(64);
+        for(let i = 0; i < buff.length; i++) {
+            buff[i] = i;
+        }
+        odata.post(buff, { headers: {'Content-Type': 'application/octet-stream'}});
+
+        const body = odata.body();
+        expect((body.match(/Content-Type: *application\/xml/gi) || []).length).toEqual(1);
+        expect((body.match(/Content-Type: *text\/html/gi) || []).length).toEqual(1);
+        expect((body.match(/Content-Type: *application\/octet-stream/gi) || []).length).toEqual(1);
+    });
+
+});
+

--- a/spec/binary_spec.js
+++ b/spec/binary_spec.js
@@ -24,7 +24,7 @@ describe('batch binary tests', function () {
   });
 
   it('should base64 encode a buffer', () => {
-    let buff = new Buffer(64);
+    let buff = Buffer.alloc ? Buffer.alloc(64) : new Buffer(64);
     for(let i = 0; i < buff.length; i++) {
       buff[i] = i;
     }


### PR DESCRIPTION
Hi

The content-type was sent 2 times in batch requests.
I create a batch test where we could add more tests specifics to batch requests :)

I also did a modification in your test on `Buffer`. `new Buffer(size)` is deprecated since NodeJS 6.
`Buffer.alloc` was introduced in 5.10.0. To keep compatibility wil older version I use `Buffer.alloc` if it exists otherwize  `new Buffer`