### PR TITLE
batch.body() returns a Buffer instead of a string when needed

### DIFF
--- a/odata.js
+++ b/odata.js
@@ -416,7 +416,7 @@ Odata.prototype.delete = function(options)
 Odata.prototype.body = function()
 {
   if(this._batch) {
-    return this._batch.body();
+    return this._batch.body().toString();
   }
   return '';
 };

--- a/spec/binary_spec.js
+++ b/spec/binary_spec.js
@@ -7,9 +7,6 @@ const config = {
   resources: 'Customers'
 };
 
-let buff = "";
-for (let i = 0; i < 256; ++i) buff += String.fromCharCode(i);
-
 describe('batch binary tests', function () {
 
   let odata;
@@ -18,20 +15,23 @@ describe('batch binary tests', function () {
   });
 
   it('should calculate body length', function () {
+    let buff = "";
+    for (let i = 0; i < 256; ++i) buff += String.fromCharCode(i);
     odata.post(buff, {headers: {'Content-Type': 'application/octet-stream'}});
     const contentLength = /\r\nContent-Length: ([0-9]+)\r\n/.exec(odata.body())[1];
     expect(contentLength).toEqual('384');
   });
 
-  it('should base64 encode a buffer', () => {
-    let buff = Buffer.alloc ? Buffer.alloc(64) : new Buffer(64);
+  it('should use buffer', () => {
+    let buff = Buffer.alloc ? Buffer.alloc(256) : new Buffer(256);
     for(let i = 0; i < buff.length; i++) {
       buff[i] = i;
     }
     odata.post(buff, { headers: {'Content-Type': 'application/octet-stream'}});
+    let bodyBatch = odata._batch.body();
     let body = odata.body();
-    expect(/Content-Length: 90/g.test(body)).toBeTruthy();
-    expect(/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0\+Pw==/g.test(body)).toBeTruthy();
+    expect(typeof body).toEqual('string');
+    expect(Buffer.isBuffer(bodyBatch)).toBeTruthy();
   });
 
 });


### PR DESCRIPTION
Hi,

I had an issue to send files to an Odata v2 server. The solution to base64 does not work, the server just ignores the header Content-Transfer-Encoding.
I modified Batch.body() to return a Buffer when a Buffer is provided.

In order to don't break compatibility, odata.body() returns a string even if a Buffer is used.

I just tested the solution with the Odata server and it works for me. I updated your test because we don't need to base64 encode Buffer anymore.

Thanks